### PR TITLE
Adapt to 0.7 Kyma release

### DIFF
--- a/internal/minikube.go
+++ b/internal/minikube.go
@@ -10,12 +10,12 @@ import (
 )
 
 const (
-	minikubeVersion string = "0.28.2"
+	minikubeVersion string = "0.33.0"
 )
 
 //RunMinikubeCmd executes a minikube command with given arguments
-func RunMinikubeCmd(args []string) (string, error) {
-	cmd := exec.Command("minikube", args[0:]...)
+func RunMinikubeCmd(args ...string) (string, error) {
+	cmd := exec.Command("minikube", args...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("Failed executing minikube command 'minikube %s' with output '%s' and error message '%s'", args, out, err)
@@ -24,16 +24,15 @@ func RunMinikubeCmd(args []string) (string, error) {
 }
 
 //RunMinikubeCmdE executes a minikube command with given arguments ignoring any errors
-func RunMinikubeCmdE(args []string) (string, error) {
-	cmd := exec.Command("minikube", args[0:]...)
+func RunMinikubeCmdE(args ...string) (string, error) {
+	cmd := exec.Command("minikube", args...)
 	out, _ := cmd.CombinedOutput()
 	return strings.Replace(string(out), "'", "", -1), nil
 }
 
 //CheckMinikubeVersion assures that the minikube version used is compatible
 func CheckMinikubeVersion() error {
-	versionCmd := []string{"version"}
-	versionText, err := RunMinikubeCmd(versionCmd)
+	versionText, err := RunMinikubeCmd("version")
 	if err != nil {
 		return err
 	}
@@ -48,7 +47,7 @@ func CheckMinikubeVersion() error {
 }
 
 func MinikubeDockerClient() (*docker.Client, error) {
-	envOut, err := RunMinikubeCmd([]string{"docker-env"})
+	envOut, err := RunMinikubeCmd("docker-env")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kyma/cmd/install.go
+++ b/pkg/kyma/cmd/install.go
@@ -4,6 +4,9 @@ import (
 	"bytes"
 	"encoding/base64"
 	"fmt"
+	"github.com/fsouza/go-dockerclient"
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
 	"io"
 	"io/ioutil"
 	"os"
@@ -11,10 +14,6 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
-
-	docker "github.com/fsouza/go-dockerclient"
-	"github.com/pkg/errors"
-	yaml "gopkg.in/yaml.v2"
 
 	"github.com/kyma-incubator/kyma-cli/internal/step"
 
@@ -450,10 +449,9 @@ func waitForInstaller(o *InstallOptions) error {
 			if desc != currentDesc {
 				if s != nil {
 					s.Success()
-				} else {
-					s = o.NewStep(fmt.Sprintf(desc))
-					currentDesc = desc
 				}
+				s = o.NewStep(fmt.Sprintf(desc))
+				currentDesc = desc
 			}
 
 		default:

--- a/pkg/kyma/cmd/provision/minikube.go
+++ b/pkg/kyma/cmd/provision/minikube.go
@@ -152,12 +152,12 @@ func (o *MinikubeOptions) Run() error {
 		return err
 	}
 
-	//s.Status("Await kube-dns to be up and running")
-	//err = internal.WaitForPod("kube-system", "k8s-app", "kube-dns")
-	//if err != nil {
-	//	s.Failure()
-	//	return err
-	//}
+	s.Status("Await kube-dns to be up and running")
+	err = internal.WaitForPod("kube-system", "k8s-app", "kube-dns")
+	if err != nil {
+		s.Failure()
+		return err
+	}
 	s.Successf("Minukube up and running")
 
 	fmt.Println("Adding hostnames, please enter your password if requested")
@@ -184,7 +184,7 @@ func (o *MinikubeOptions) Run() error {
 }
 
 func checkIfMinikubeIsInitialized(o *MinikubeOptions) error {
-	statusText, err := internal.RunMinikubeCmdE("status")
+	statusText, err := internal.RunMinikubeCmdE("status", "-b", bootstrapper)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
In Kyma 0.7 newer kubernetes and Minikube are used. This PR bumps this in CLI code and adapts to new versions of those tools.

As a bonus following bugs are fixed:
#20 
#19 
Problem with displaying installation steps 