### PR TITLE
consistent requirement checks

### DIFF
--- a/internal/const_unix.go
+++ b/internal/const_unix.go
@@ -1,6 +1,0 @@
-// +build !windows
-
-package internal
-
-//HOSTS_FILE the hosts file name on the system
-const HOSTS_FILE = "/etc/hosts"

--- a/internal/const_windows.go
+++ b/internal/const_windows.go
@@ -1,6 +1,0 @@
-// +build windows
-
-package internal
-
-//HOSTS_FILE the hosts file name on the system
-const HOSTS_FILE = "C:\\Windows\\system32\\drivers\\etc\\hosts"

--- a/internal/kubectl/kubectl.go
+++ b/internal/kubectl/kubectl.go
@@ -58,7 +58,7 @@ func execCmd(cmd *exec.Cmd, inputText string, verbose bool) (string, error) {
 		return unquotedOut, fmt.Errorf("Failed executing kubectl command 'kubectl %s' with output '%s' and error message '%s'", inputText, out, err)
 	}
 	if verbose {
-		fmt.Printf("\nExecuted kubectl command:\n  %s\nwith output:\n  %s\n", inputText, string(out))
+		fmt.Printf("\nExecuted command:\n  kubectl %s\nwith output:\n  %s\n", inputText, string(out))
 	}
 	return unquotedOut, nil
 }

--- a/internal/kubectl/kubectl.go
+++ b/internal/kubectl/kubectl.go
@@ -206,5 +206,5 @@ func CheckVersion(verbose bool) (string, error) {
 		return "", nil
 	}
 
-	return fmt.Sprintf("You are using an unsupported minikube version '%s'. This may not work. It is recommended to use minikube version '%s'", version, kubectlVersion), nil
+	return fmt.Sprintf("You are using an unsupported kubectl version '%s'. This may not work. It is recommended to use kubectl version '%s'", version, kubectlVersion), nil
 }

--- a/internal/kubectl/kubectl.go
+++ b/internal/kubectl/kubectl.go
@@ -25,7 +25,7 @@ func RunCmd(verbose bool, args ...string) (string, error) {
 }
 
 //RunApplyCmd executes a kubectl apply command with given resources
-func RunApplyCmd(resources []interface{}, verbose bool) (string, error) {
+func RunApplyCmd(resources []map[string]interface{}, verbose bool) (string, error) {
 	cmd := exec.Command("kubectl", "apply", "-f", "-")
 	buf := &bytes.Buffer{}
 	enc := yaml.NewEncoder(buf)

--- a/internal/kubectl/kubectl.go
+++ b/internal/kubectl/kubectl.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	kubectlVersion string = "1.10.0"
+	kubectlVersion string = "1.11.0"
 	sleep                 = 5 * time.Second
 )
 
@@ -27,20 +27,15 @@ func RunCmd(verbose bool, args ...string) (string, error) {
 //RunApplyCmd executes a kubectl apply command with given resources
 func RunApplyCmd(resources []map[string]interface{}, verbose bool) (string, error) {
 	cmd := exec.Command("kubectl", "apply", "-f", "-")
-	stdinPipe, err := cmd.StdinPipe()
-	if err != nil {
-		return "", err
-	}
-	defer func() { _ = stdinPipe.Close() }()
 	buf := &bytes.Buffer{}
 	enc := yaml.NewEncoder(buf)
 	for _, y := range resources {
-		err = enc.Encode(y)
+		err := enc.Encode(y)
 		if err != nil {
 			return "", err
 		}
 	}
-	err = enc.Close()
+	err := enc.Close()
 	if err != nil {
 		return "", err
 	}

--- a/internal/kubectl/kubectl.go
+++ b/internal/kubectl/kubectl.go
@@ -25,7 +25,7 @@ func RunCmd(verbose bool, args ...string) (string, error) {
 }
 
 //RunApplyCmd executes a kubectl apply command with given resources
-func RunApplyCmd(resources []map[string]interface{}, verbose bool) (string, error) {
+func RunApplyCmd(resources []interface{}, verbose bool) (string, error) {
 	cmd := exec.Command("kubectl", "apply", "-f", "-")
 	buf := &bytes.Buffer{}
 	enc := yaml.NewEncoder(buf)

--- a/internal/kyma.go
+++ b/internal/kyma.go
@@ -7,8 +7,8 @@ import (
 )
 
 //GetKymaVersion determines the version of kyma installed to current cluster
-func GetKymaVersion() (string, error) {
-	kymaVersion, err := kubectl.RunCmd([]string{"-n", "kyma-installer", "get", "pod", "-l", "name=kyma-installer", "-o", "jsonpath='{.items[*].spec.containers[0].image}'"})
+func GetKymaVersion(verbose bool) (string, error) {
+	kymaVersion, err := kubectl.RunCmd(verbose, "-n", "kyma-installer", "get", "pod", "-l", "name=kyma-installer", "-o", "jsonpath='{.items[*].spec.containers[0].image}'")
 	if err != nil {
 		return "", err
 	}

--- a/internal/kyma.go
+++ b/internal/kyma.go
@@ -2,11 +2,13 @@ package internal
 
 import (
 	"strings"
+
+	"github.com/kyma-incubator/kyma-cli/internal/kubectl"
 )
 
 //GetKymaVersion determines the version of kyma installed to current cluster
 func GetKymaVersion() (string, error) {
-	kymaVersion, err := RunKubectlCmd([]string{"-n", "kyma-installer", "get", "pod", "-l", "name=kyma-installer", "-o", "jsonpath='{.items[*].spec.containers[0].image}'"})
+	kymaVersion, err := kubectl.RunCmd([]string{"-n", "kyma-installer", "get", "pod", "-l", "name=kyma-installer", "-o", "jsonpath='{.items[*].spec.containers[0].image}'"})
 	if err != nil {
 		return "", err
 	}

--- a/internal/minikube/minikube.go
+++ b/internal/minikube/minikube.go
@@ -16,19 +16,26 @@ const (
 )
 
 //RunCmd executes a minikube command with given arguments
-func RunCmd(args ...string) (string, error) {
+func RunCmd(verbose bool, args ...string) (string, error) {
 	cmd := exec.Command("minikube", args...)
 	out, err := cmd.CombinedOutput()
 	unquotedOut := strings.Replace(string(out), "'", "", -1)
+
 	if err != nil {
+		if verbose {
+			fmt.Printf("\nExecuted command:\n  minikube %s\nwith output:\n  %s\nand error:\n  %s\n", strings.Join(args, " "), string(out), err)
+		}
 		return unquotedOut, fmt.Errorf("Failed executing minikube command 'minikube %s' with output '%s' and error message '%s'", args, out, err)
+	}
+	if verbose {
+		fmt.Printf("\nExecuted minikube command:\n  %s\nwith output:\n  %s\n", args, string(out))
 	}
 	return unquotedOut, nil
 }
 
 //CheckVersion checks whether minikube version is supported
-func CheckVersion() (string, error) {
-	versionText, err := RunCmd("version")
+func CheckVersion(verbose bool) (string, error) {
+	versionText, err := RunCmd(verbose, "version")
 	if err != nil {
 		return "", err
 	}
@@ -53,8 +60,9 @@ func CheckVersion() (string, error) {
 	return fmt.Sprintf("You are using an unsupported minikube version '%s'. This may not work. It is recommended to use minikube version '%s'", version, minikubeVersion), nil
 }
 
-func DockerClient() (*docker.Client, error) {
-	envOut, err := RunCmd("docker-env")
+//DockerClient creates a docker client based on minikube "docker-env" configuration
+func DockerClient(verbose bool) (*docker.Client, error) {
+	envOut, err := RunCmd(verbose, "docker-env")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/minikube/minikube.go
+++ b/internal/minikube/minikube.go
@@ -25,10 +25,10 @@ func RunCmd(verbose bool, args ...string) (string, error) {
 		if verbose {
 			fmt.Printf("\nExecuted command:\n  minikube %s\nwith output:\n  %s\nand error:\n  %s\n", strings.Join(args, " "), string(out), err)
 		}
-		return unquotedOut, fmt.Errorf("Failed executing minikube command 'minikube %s' with output '%s' and error message '%s'", args, out, err)
+		return unquotedOut, fmt.Errorf("Failed executing command 'minikube %s' with output '%s' and error message '%s'", strings.Join(args, " "), out, err)
 	}
 	if verbose {
-		fmt.Printf("\nExecuted minikube command:\n  %s\nwith output:\n  %s\n", args, string(out))
+		fmt.Printf("\nExecuted command:\n  minikube %s\nwith output:\n  %s\n", strings.Join(args, " "), string(out))
 	}
 	return unquotedOut, nil
 }

--- a/internal/step/factory.go
+++ b/internal/step/factory.go
@@ -1,11 +1,13 @@
 package step
 
+import "runtime"
+
 type Factory struct {
 	NonInteractive bool
 }
 
 func (f *Factory) NewStep(msg string) Step {
-	if f.NonInteractive {
+	if f.NonInteractive || runtime.GOOS != "darwin" {
 		return NewSimpleStep(msg)
 	}
 	return NewStepWithSpinner(msg)

--- a/internal/step/gliphs_darwin.go
+++ b/internal/step/gliphs_darwin.go
@@ -1,0 +1,12 @@
+// +build darwin
+
+package step
+
+const (
+	successGliph  = "✅ "
+	failureGliph  = "❌ "
+	warningGliph  = "⚠️  "
+	questionGliph = "❓ "
+	infoGliph     = "ℹ️  "
+	waitGliph     = "🕑 "
+)

--- a/internal/step/gliphs_others.go
+++ b/internal/step/gliphs_others.go
@@ -7,6 +7,6 @@ const (
 	failureGliph  = "X "
 	warningGliph  = "! "
 	questionGliph = "? "
-	infoGliph     = "I "
+	infoGliph     = "- "
 	waitGliph     = "- "
 )

--- a/internal/step/gliphs_others.go
+++ b/internal/step/gliphs_others.go
@@ -1,0 +1,12 @@
+// +build !darwin
+
+package step
+
+const (
+	successGliph  = "- "
+	failureGliph  = "X "
+	warningGliph  = "! "
+	questionGliph = "? "
+	infoGliph     = "I "
+	waitGliph     = "- "
+)

--- a/internal/step/simple.go
+++ b/internal/step/simple.go
@@ -1,0 +1,78 @@
+package step
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+func NewSimpleStep(msg string) Step {
+	return &simpleStep{msg}
+}
+
+type simpleStep struct {
+	msg string
+}
+
+func (s *simpleStep) Start() {
+	fmt.Println(s.msg)
+}
+
+func (s *simpleStep) Status(msg string) {
+	fmt.Printf("%s %s : %s\n", waitGliph, s.msg, msg)
+}
+
+func (s *simpleStep) Success() {
+	s.Stop(true)
+}
+
+func (s *simpleStep) Successf(format string, args ...interface{}) {
+	s.Stopf(true, format, args...)
+}
+
+func (s *simpleStep) Failure() {
+	s.Stop(false)
+}
+
+func (s *simpleStep) Failuref(format string, args ...interface{}) {
+	s.Stopf(false, format, args...)
+}
+
+func (s *simpleStep) Stopf(success bool, format string, args ...interface{}) {
+	s.msg = fmt.Sprintf(format, args...)
+	s.Stop(success)
+}
+
+func (s *simpleStep) Stop(success bool) {
+	var glyph string
+	if success {
+		glyph = successGliph
+	} else {
+		glyph = failureGliph
+	}
+	fmt.Printf("%s %s\n", glyph, s.msg)
+}
+
+func (s *simpleStep) LogInfo(msg string) {
+	fmt.Printf("%s  %s\n", infoGliph, msg)
+}
+
+func (s *simpleStep) LogInfof(format string, args ...interface{}) {
+	s.LogInfo(fmt.Sprintf(format, args...))
+}
+
+func (s *simpleStep) LogError(msg string) {
+	_, _ = fmt.Fprintf(os.Stderr, "%s  %s\n", warningGliph, msg)
+}
+
+func (s *simpleStep) LogErrorf(format string, args ...interface{}) {
+	s.LogError(fmt.Sprintf(format, args...))
+}
+
+func (s *simpleStep) Prompt(msg string) (string, error) {
+	reader := bufio.NewReader(os.Stdin)
+	fmt.Printf("%s %s", questionGliph, msg)
+	answer, err := reader.ReadString('\n')
+	return strings.TrimSpace(answer), err
+}

--- a/internal/step/simple.go
+++ b/internal/step/simple.go
@@ -20,7 +20,7 @@ func (s *simpleStep) Start() {
 }
 
 func (s *simpleStep) Status(msg string) {
-	fmt.Printf("%s %s : %s\n", waitGliph, s.msg, msg)
+	fmt.Printf("%s%s : %s\n", waitGliph, s.msg, msg)
 }
 
 func (s *simpleStep) Success() {
@@ -51,11 +51,11 @@ func (s *simpleStep) Stop(success bool) {
 	} else {
 		glyph = failureGliph
 	}
-	fmt.Printf("%s %s\n", glyph, s.msg)
+	fmt.Printf("%s%s\n", glyph, s.msg)
 }
 
 func (s *simpleStep) LogInfo(msg string) {
-	fmt.Printf("%s  %s\n", infoGliph, msg)
+	fmt.Printf("%s%s\n", infoGliph, msg)
 }
 
 func (s *simpleStep) LogInfof(format string, args ...interface{}) {
@@ -63,7 +63,7 @@ func (s *simpleStep) LogInfof(format string, args ...interface{}) {
 }
 
 func (s *simpleStep) LogError(msg string) {
-	_, _ = fmt.Fprintf(os.Stderr, "%s  %s\n", warningGliph, msg)
+	_, _ = fmt.Fprintf(os.Stderr, "%s%s\n", warningGliph, msg)
 }
 
 func (s *simpleStep) LogErrorf(format string, args ...interface{}) {
@@ -72,7 +72,7 @@ func (s *simpleStep) LogErrorf(format string, args ...interface{}) {
 
 func (s *simpleStep) Prompt(msg string) (string, error) {
 	reader := bufio.NewReader(os.Stdin)
-	fmt.Printf("%s %s", questionGliph, msg)
+	fmt.Printf("%s%s", questionGliph, msg)
 	answer, err := reader.ReadString('\n')
 	return strings.TrimSpace(answer), err
 }

--- a/internal/step/spinner.go
+++ b/internal/step/spinner.go
@@ -17,7 +17,7 @@ func NewStepWithSpinner(msg string) Step {
 		time.Millisecond*200,
 		spinner.WithColor("reset"),
 	)
-	s.Prefix = msg + " "
+	s.Prefix = waitGliph + msg + " "
 	return &stepWithSpinner{s, msg}
 }
 
@@ -62,24 +62,24 @@ func (s *stepWithSpinner) Stop(success bool) {
 	} else {
 		gliph = failureGliph
 	}
-	s.spinner.FinalMSG = fmt.Sprintf("%s %s\n", gliph, s.msg)
+	s.spinner.FinalMSG = fmt.Sprintf("%s%s\n", gliph, s.msg)
 	s.spinner.Stop()
 }
 
 func (s *stepWithSpinner) LogInfo(msg string) {
-	s.logTof(os.Stdout, infoGliph+"  "+msg)
+	s.logTof(os.Stdout, infoGliph+msg)
 }
 
 func (s *stepWithSpinner) LogInfof(format string, args ...interface{}) {
-	s.logTof(os.Stdout, infoGliph+"  "+format, args...)
+	s.logTof(os.Stdout, infoGliph+format, args...)
 }
 
 func (s *stepWithSpinner) LogError(msg string) {
-	s.logTof(os.Stderr, warningGliph+"  "+msg)
+	s.logTof(os.Stderr, warningGliph+msg)
 }
 
 func (s *stepWithSpinner) LogErrorf(format string, args ...interface{}) {
-	s.logTof(os.Stderr, warningGliph+"  "+format, args)
+	s.logTof(os.Stderr, warningGliph+format, args)
 }
 
 func (s *stepWithSpinner) logTof(to io.Writer, format string, args ...interface{}) {
@@ -95,7 +95,7 @@ func (s *stepWithSpinner) Prompt(msg string) (string, error) {
 	reader := bufio.NewReader(os.Stdin)
 	isActive := s.spinner.Active()
 	s.spinner.Stop()
-	fmt.Printf("%s %s", questionGliph, msg)
+	fmt.Printf("%s%s", questionGliph, msg)
 	answer, err := reader.ReadString('\n')
 	if isActive {
 		s.spinner.Start()

--- a/internal/step/spinner.go
+++ b/internal/step/spinner.go
@@ -58,28 +58,28 @@ func (s *stepWithSpinner) Stopf(success bool, format string, args ...interface{}
 func (s *stepWithSpinner) Stop(success bool) {
 	var gliph string
 	if success {
-		gliph = successGliph
+		gliph = SuccessGliph
 	} else {
-		gliph = failureGliph
+		gliph = FailureGliph
 	}
 	s.spinner.FinalMSG = fmt.Sprintf("%s %s\n", gliph, s.msg)
 	s.spinner.Stop()
 }
 
 func (s *stepWithSpinner) LogInfo(msg string) {
-	s.logTof(os.Stdout, infoGliph+"  "+msg)
+	s.logTof(os.Stdout, InfoGliph+"  "+msg)
 }
 
 func (s *stepWithSpinner) LogInfof(format string, args ...interface{}) {
-	s.logTof(os.Stdout, infoGliph+"  "+format, args...)
+	s.logTof(os.Stdout, InfoGliph+"  "+format, args...)
 }
 
 func (s *stepWithSpinner) LogError(msg string) {
-	s.logTof(os.Stderr, warningGliph+"  "+msg)
+	s.logTof(os.Stderr, WarningGliph+"  "+msg)
 }
 
 func (s *stepWithSpinner) LogErrorf(format string, args ...interface{}) {
-	s.logTof(os.Stderr, warningGliph+"  "+format, args)
+	s.logTof(os.Stderr, WarningGliph+"  "+format, args)
 }
 
 func (s *stepWithSpinner) logTof(to io.Writer, format string, args ...interface{}) {
@@ -95,7 +95,7 @@ func (s *stepWithSpinner) Prompt(msg string) (string, error) {
 	reader := bufio.NewReader(os.Stdin)
 	isActive := s.spinner.Active()
 	s.spinner.Stop()
-	fmt.Printf("%s %s", questionGliph, msg)
+	fmt.Printf("%s %s", QuestionGliph, msg)
 	answer, err := reader.ReadString('\n')
 	if isActive {
 		s.spinner.Start()

--- a/internal/step/spinner.go
+++ b/internal/step/spinner.go
@@ -62,7 +62,7 @@ func (s *stepWithSpinner) Stop(success bool) {
 	} else {
 		gliph = failureGliph
 	}
-	s.spinner.FinalMSG = fmt.Sprintf("%s %s\n", s.msg, gliph)
+	s.spinner.FinalMSG = fmt.Sprintf("%s %s\n", gliph, s.msg)
 	s.spinner.Stop()
 }
 

--- a/internal/step/spinner.go
+++ b/internal/step/spinner.go
@@ -67,11 +67,11 @@ func (s *stepWithSpinner) Stop(success bool) {
 }
 
 func (s *stepWithSpinner) LogInfo(msg string) {
-	s.logTof(os.Stdout, msg)
+	s.logTof(os.Stdout, infoGliph+"  "+msg)
 }
 
 func (s *stepWithSpinner) LogInfof(format string, args ...interface{}) {
-	s.logTof(os.Stdout, format, args...)
+	s.logTof(os.Stdout, infoGliph+"  "+format, args...)
 }
 
 func (s *stepWithSpinner) LogError(msg string) {
@@ -95,7 +95,7 @@ func (s *stepWithSpinner) Prompt(msg string) (string, error) {
 	reader := bufio.NewReader(os.Stdin)
 	isActive := s.spinner.Active()
 	s.spinner.Stop()
-	fmt.Printf(msg)
+	fmt.Printf("%s %s", questionGliph, msg)
 	answer, err := reader.ReadString('\n')
 	if isActive {
 		s.spinner.Start()

--- a/internal/step/spinner.go
+++ b/internal/step/spinner.go
@@ -58,28 +58,28 @@ func (s *stepWithSpinner) Stopf(success bool, format string, args ...interface{}
 func (s *stepWithSpinner) Stop(success bool) {
 	var gliph string
 	if success {
-		gliph = SuccessGliph
+		gliph = successGliph
 	} else {
-		gliph = FailureGliph
+		gliph = failureGliph
 	}
 	s.spinner.FinalMSG = fmt.Sprintf("%s %s\n", gliph, s.msg)
 	s.spinner.Stop()
 }
 
 func (s *stepWithSpinner) LogInfo(msg string) {
-	s.logTof(os.Stdout, InfoGliph+"  "+msg)
+	s.logTof(os.Stdout, infoGliph+"  "+msg)
 }
 
 func (s *stepWithSpinner) LogInfof(format string, args ...interface{}) {
-	s.logTof(os.Stdout, InfoGliph+"  "+format, args...)
+	s.logTof(os.Stdout, infoGliph+"  "+format, args...)
 }
 
 func (s *stepWithSpinner) LogError(msg string) {
-	s.logTof(os.Stderr, WarningGliph+"  "+msg)
+	s.logTof(os.Stderr, warningGliph+"  "+msg)
 }
 
 func (s *stepWithSpinner) LogErrorf(format string, args ...interface{}) {
-	s.logTof(os.Stderr, WarningGliph+"  "+format, args)
+	s.logTof(os.Stderr, warningGliph+"  "+format, args)
 }
 
 func (s *stepWithSpinner) logTof(to io.Writer, format string, args ...interface{}) {
@@ -95,7 +95,7 @@ func (s *stepWithSpinner) Prompt(msg string) (string, error) {
 	reader := bufio.NewReader(os.Stdin)
 	isActive := s.spinner.Active()
 	s.spinner.Stop()
-	fmt.Printf("%s %s", QuestionGliph, msg)
+	fmt.Printf("%s %s", questionGliph, msg)
 	answer, err := reader.ReadString('\n')
 	if isActive {
 		s.spinner.Start()

--- a/internal/step/spinner.go
+++ b/internal/step/spinner.go
@@ -3,11 +3,12 @@ package step
 import (
 	"bufio"
 	"fmt"
-	"github.com/briandowns/spinner"
 	"io"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/briandowns/spinner"
 )
 
 func NewStepWithSpinner(msg string) Step {
@@ -74,13 +75,12 @@ func (s *stepWithSpinner) LogInfof(format string, args ...interface{}) {
 }
 
 func (s *stepWithSpinner) LogError(msg string) {
-	s.logTof(os.Stderr, msg)
+	s.logTof(os.Stderr, warningGliph+"  "+msg)
 }
 
 func (s *stepWithSpinner) LogErrorf(format string, args ...interface{}) {
-	s.logTof(os.Stderr, format, args...)
+	s.logTof(os.Stderr, warningGliph+"  "+format, args)
 }
-
 
 func (s *stepWithSpinner) logTof(to io.Writer, format string, args ...interface{}) {
 	isActive := s.spinner.Active()

--- a/internal/step/step.go
+++ b/internal/step/step.go
@@ -15,12 +15,3 @@ type Step interface {
 	LogErrorf(format string, args ...interface{})
 	Prompt(msg string) (string, error)
 }
-
-const (
-	successGliph  = "✅"
-	failureGliph  = "❌"
-	warningGliph  = "⚠️"
-	questionGliph = "❓"
-	infoGliph     = "ℹ️"
-	waitGliph     = "🕑"
-)

--- a/internal/step/step.go
+++ b/internal/step/step.go
@@ -24,9 +24,11 @@ type Step interface {
 }
 
 const (
-	successGliph = "✅"
-	failureGliph = "❌"
-	warningGliph = "⚠️"
+	successGliph  = "✅"
+	failureGliph  = "❌"
+	warningGliph  = "⚠️"
+	questionGliph = "❓"
+	infoGliph     = "ℹ️"
 )
 
 func NewSimpleStep(msg string) Step {
@@ -77,11 +79,11 @@ func (s *simpleStep) Stop(success bool) {
 }
 
 func (s *simpleStep) LogInfo(msg string) {
-	fmt.Println(msg)
+	fmt.Printf("%s %s\n", infoGliph, msg)
 }
 
 func (s *simpleStep) LogInfof(format string, args ...interface{}) {
-	fmt.Printf(format+"\n", args...)
+	s.LogInfo(fmt.Sprintf(format, args...))
 }
 
 func (s *simpleStep) LogError(msg string) {
@@ -89,12 +91,12 @@ func (s *simpleStep) LogError(msg string) {
 }
 
 func (s *simpleStep) LogErrorf(format string, args ...interface{}) {
-	_, _ = fmt.Fprintf(os.Stderr, format+"\n", args...)
+	s.LogError(fmt.Sprintf(format, args...))
 }
 
 func (s *simpleStep) Prompt(msg string) (string, error) {
 	reader := bufio.NewReader(os.Stdin)
-	fmt.Printf(msg)
+	fmt.Printf("%s %s", questionGliph, msg)
 	answer, err := reader.ReadString('\n')
 	return strings.TrimSpace(answer), err
 }

--- a/internal/step/step.go
+++ b/internal/step/step.go
@@ -1,12 +1,5 @@
 package step
 
-import (
-	"bufio"
-	"fmt"
-	"os"
-	"strings"
-)
-
 type Step interface {
 	Start()
 	Status(msg string)
@@ -24,79 +17,10 @@ type Step interface {
 }
 
 const (
-	SuccessGliph  = "✅"
-	FailureGliph  = "❌"
-	WarningGliph  = "⚠️"
-	QuestionGliph = "❓"
-	InfoGliph     = "ℹ️"
+	successGliph  = "✅"
+	failureGliph  = "❌"
+	warningGliph  = "⚠️"
+	questionGliph = "❓"
+	infoGliph     = "ℹ️"
+	waitGliph     = "🕑"
 )
-
-func NewSimpleStep(msg string) Step {
-	return &simpleStep{msg}
-}
-
-type simpleStep struct {
-	msg string
-}
-
-func (s *simpleStep) Start() {
-	fmt.Println(s.msg)
-}
-
-func (s *simpleStep) Status(msg string) {
-	fmt.Printf("%s : %s\n", s.msg, msg)
-}
-
-func (s *simpleStep) Success() {
-	s.Stop(true)
-}
-
-func (s *simpleStep) Successf(format string, args ...interface{}) {
-	s.Stopf(true, format, args...)
-}
-
-func (s *simpleStep) Failure() {
-	s.Stop(false)
-}
-
-func (s *simpleStep) Failuref(format string, args ...interface{}) {
-	s.Stopf(false, format, args...)
-}
-
-func (s *simpleStep) Stopf(success bool, format string, args ...interface{}) {
-	s.msg = fmt.Sprintf(format, args...)
-	s.Stop(success)
-}
-
-func (s *simpleStep) Stop(success bool) {
-	var glyph string
-	if success {
-		glyph = SuccessGliph
-	} else {
-		glyph = FailureGliph
-	}
-	fmt.Printf("%s %s\n", s.msg, glyph)
-}
-
-func (s *simpleStep) LogInfo(msg string) {
-	fmt.Printf("%s %s\n", InfoGliph, msg)
-}
-
-func (s *simpleStep) LogInfof(format string, args ...interface{}) {
-	s.LogInfo(fmt.Sprintf(format, args...))
-}
-
-func (s *simpleStep) LogError(msg string) {
-	_, _ = fmt.Fprintln(os.Stderr, msg)
-}
-
-func (s *simpleStep) LogErrorf(format string, args ...interface{}) {
-	s.LogError(fmt.Sprintf(format, args...))
-}
-
-func (s *simpleStep) Prompt(msg string) (string, error) {
-	reader := bufio.NewReader(os.Stdin)
-	fmt.Printf("%s %s", QuestionGliph, msg)
-	answer, err := reader.ReadString('\n')
-	return strings.TrimSpace(answer), err
-}

--- a/internal/step/step.go
+++ b/internal/step/step.go
@@ -24,11 +24,11 @@ type Step interface {
 }
 
 const (
-	successGliph  = "✅"
-	failureGliph  = "❌"
-	warningGliph  = "⚠️"
-	questionGliph = "❓"
-	infoGliph     = "ℹ️"
+	SuccessGliph  = "✅"
+	FailureGliph  = "❌"
+	WarningGliph  = "⚠️"
+	QuestionGliph = "❓"
+	InfoGliph     = "ℹ️"
 )
 
 func NewSimpleStep(msg string) Step {
@@ -71,15 +71,15 @@ func (s *simpleStep) Stopf(success bool, format string, args ...interface{}) {
 func (s *simpleStep) Stop(success bool) {
 	var glyph string
 	if success {
-		glyph = successGliph
+		glyph = SuccessGliph
 	} else {
-		glyph = failureGliph
+		glyph = FailureGliph
 	}
 	fmt.Printf("%s %s\n", s.msg, glyph)
 }
 
 func (s *simpleStep) LogInfo(msg string) {
-	fmt.Printf("%s %s\n", infoGliph, msg)
+	fmt.Printf("%s %s\n", InfoGliph, msg)
 }
 
 func (s *simpleStep) LogInfof(format string, args ...interface{}) {
@@ -96,7 +96,7 @@ func (s *simpleStep) LogErrorf(format string, args ...interface{}) {
 
 func (s *simpleStep) Prompt(msg string) (string, error) {
 	reader := bufio.NewReader(os.Stdin)
-	fmt.Printf("%s %s", questionGliph, msg)
+	fmt.Printf("%s %s", QuestionGliph, msg)
 	answer, err := reader.ReadString('\n')
 	return strings.TrimSpace(answer), err
 }

--- a/internal/step/step.go
+++ b/internal/step/step.go
@@ -26,6 +26,7 @@ type Step interface {
 const (
 	successGliph = "✅"
 	failureGliph = "❌"
+	warningGliph = "⚠️"
 )
 
 func NewSimpleStep(msg string) Step {

--- a/pkg/kyma/cmd/install.go
+++ b/pkg/kyma/cmd/install.go
@@ -80,7 +80,7 @@ func (o *InstallOptions) Run() error {
 		return err
 	}
 
-	s := o.NewStep(fmt.Sprintf("Checking requirements"))
+	s := o.NewStep("Checking requirements")
 	err = checkInstallRequirements(o, s)
 	if err != nil {
 		s.Failure()
@@ -89,12 +89,12 @@ func (o *InstallOptions) Run() error {
 	s.Successf("Requirements are fine")
 
 	if o.Local {
-		fmt.Printf("%s Installing Kyma from local path: '%s'\n", step.InfoGliph, o.LocalSrcPath)
+		s.LogInfof("Installing Kyma from local path: '%s'",  o.LocalSrcPath)
 	} else {
-		fmt.Printf("%s Installing Kyma in version '%s'\n", step.InfoGliph, o.ReleaseVersion)
+		s.LogInfof("Installing Kyma in version '%s'", o.ReleaseVersion)
 	}
 
-	s = o.NewStep(fmt.Sprintf("Installing tiller"))
+	s = o.NewStep("Installing tiller")
 	err = installTiller(o)
 	if err != nil {
 		s.Failure()
@@ -102,7 +102,7 @@ func (o *InstallOptions) Run() error {
 	}
 	s.Successf("Tiller installed")
 
-	s = o.NewStep(fmt.Sprintf("Installing kyma-installer"))
+	s = o.NewStep("Installing kyma-installer")
 	err = installInstaller(o)
 	if err != nil {
 		s.Failure()
@@ -110,7 +110,7 @@ func (o *InstallOptions) Run() error {
 	}
 	s.Successf("kyma-installer installed")
 
-	s = o.NewStep(fmt.Sprintf("Requesting kyma-installer to install kyma"))
+	s = o.NewStep("Requesting kyma-installer to install kyma")
 	err = activateInstaller(o)
 	if err != nil {
 		s.Failure()

--- a/pkg/kyma/cmd/install.go
+++ b/pkg/kyma/cmd/install.go
@@ -86,14 +86,13 @@ func (o *InstallOptions) Run() error {
 		s.Failure()
 		return err
 	}
-	s.Successf("Requirements are fine")
 
 	if o.Local {
-		fmt.Printf("Installing Kyma from local path: '%s'\n", o.LocalSrcPath)
+		s.LogInfof("Installing Kyma from local path: '%s'\n", o.LocalSrcPath)
 	} else {
-		fmt.Printf("Installing Kyma in version '%s'\n", o.ReleaseVersion)
+		s.LogInfof("Installing Kyma in version '%s'\n", o.ReleaseVersion)
 	}
-	fmt.Println()
+	s.Successf("Requirements are fine")
 
 	s = o.NewStep(fmt.Sprintf("Installing tiller"))
 	err = installTiller(o)
@@ -227,7 +226,7 @@ func installInstaller(o *InstallOptions) error {
 }
 
 func installInstallerFromRelease(o *InstallOptions) error {
-	relaseURL := "https://github.com/kyma-project/kyma/releases/download/" + o.ReleaseVersion + "/kyma-config-local.yaml"
+	relaseURL := "https://github.com/kyma-project/kyma/releases/download/" + o.ReleaseVersion + "/kyma-installer-local.yaml"
 	_, err := kubectl.RunCmd(o.Verbose, "apply", "-f", relaseURL)
 	if err != nil {
 		return err

--- a/pkg/kyma/cmd/install.go
+++ b/pkg/kyma/cmd/install.go
@@ -86,13 +86,13 @@ func (o *InstallOptions) Run() error {
 		s.Failure()
 		return err
 	}
+	s.Successf("Requirements are fine")
 
 	if o.Local {
-		s.LogInfof("Installing Kyma from local path: '%s'\n", o.LocalSrcPath)
+		fmt.Printf("%s Installing Kyma from local path: '%s'\n", step.InfoGliph, o.LocalSrcPath)
 	} else {
-		s.LogInfof("Installing Kyma in version '%s'\n", o.ReleaseVersion)
+		fmt.Printf("%s Installing Kyma in version '%s'\n", step.InfoGliph, o.ReleaseVersion)
 	}
-	s.Successf("Requirements are fine")
 
 	s = o.NewStep(fmt.Sprintf("Installing tiller"))
 	err = installTiller(o)

--- a/pkg/kyma/cmd/provision/minikube/cmd.go
+++ b/pkg/kyma/cmd/provision/minikube/cmd.go
@@ -97,8 +97,9 @@ func (o *MinikubeOptions) Run() error {
 		s.Failure()
 		return err
 	}
-	s.LogInfof("Preparing minikube using domain '%s' and vm-driver '%s'\n", o.Domain, o.VMDriver)
 	s.Successf("Requirements are fine")
+
+	fmt.Printf("%s Preparing minikube using domain '%s' and vm-driver '%s'\n", step.InfoGliph, o.Domain, o.VMDriver)
 
 	s = o.NewStep("Check minikube status")
 	err = checkIfMinikubeIsInitialized(o, s)
@@ -147,14 +148,14 @@ func (o *MinikubeOptions) Run() error {
 	}
 	s.Successf("Minukube up and running")
 
-	s = o.NewStep(fmt.Sprintf("Adjusting minikube cluster"))
-	s.LogInfo("Adding hostnames, please enter your password if requested")
+	fmt.Printf("%s Adding hostnames, please enter your password if requested\n", step.InfoGliph)
 	err = addDevDomainsToEtcHosts(o)
 	if err != nil {
 		return err
 	}
-	s.LogInfof("Hostnames added to %s", HostsFile)
+	fmt.Printf("%s Hostnames added to %s\n", step.InfoGliph, HostsFile)
 
+	s = o.NewStep(fmt.Sprintf("Adjusting minikube cluster"))
 	err = increaseFsInotifyMaxUserInstances(o)
 	if err != nil {
 		s.Failure()

--- a/pkg/kyma/cmd/provision/minikube/cmd.go
+++ b/pkg/kyma/cmd/provision/minikube/cmd.go
@@ -99,9 +99,9 @@ func (o *MinikubeOptions) Run() error {
 	}
 	s.Successf("Requirements are fine")
 
+	s.LogInfof("Preparing minikube using domain '%s' and vm-driver '%s'", o.Domain, o.VMDriver)
 
 	s = o.NewStep("Check minikube status")
-	s.LogInfof("Preparing minikube using domain '%s' and vm-driver '%s'", o.Domain, o.VMDriver)
 	err = checkIfMinikubeIsInitialized(o, s)
 	if err != nil {
 		s.Failure()

--- a/pkg/kyma/cmd/provision/minikube/cmd.go
+++ b/pkg/kyma/cmd/provision/minikube/cmd.go
@@ -99,9 +99,9 @@ func (o *MinikubeOptions) Run() error {
 	}
 	s.Successf("Requirements are fine")
 
-	fmt.Printf("%s Preparing minikube using domain '%s' and vm-driver '%s'\n", step.InfoGliph, o.Domain, o.VMDriver)
 
 	s = o.NewStep("Check minikube status")
+	s.LogInfof("Preparing minikube using domain '%s' and vm-driver '%s'", o.Domain, o.VMDriver)
 	err = checkIfMinikubeIsInitialized(o, s)
 	if err != nil {
 		s.Failure()
@@ -148,12 +148,12 @@ func (o *MinikubeOptions) Run() error {
 	}
 	s.Successf("Minukube up and running")
 
-	fmt.Printf("%s Adding hostnames, please enter your password if requested\n", step.InfoGliph)
+	s.LogInfo("Adding hostnames, please enter your password if requested")
 	err = addDevDomainsToEtcHosts(o)
 	if err != nil {
 		return err
 	}
-	fmt.Printf("%s Hostnames added to %s\n", step.InfoGliph, HostsFile)
+	s.LogInfof("Hostnames added to %s", HostsFile)
 
 	s = o.NewStep(fmt.Sprintf("Adjusting minikube cluster"))
 	err = increaseFsInotifyMaxUserInstances(o)
@@ -161,7 +161,7 @@ func (o *MinikubeOptions) Run() error {
 		s.Failure()
 		return err
 	}
-	s.Successf("Minikube cluster adjusted")
+	s.Success()
 
 	err = printSummary(o)
 	if err != nil {

--- a/pkg/kyma/cmd/provision/minikube/cmd.go
+++ b/pkg/kyma/cmd/provision/minikube/cmd.go
@@ -97,10 +97,8 @@ func (o *MinikubeOptions) Run() error {
 		s.Failure()
 		return err
 	}
+	s.LogInfof("Preparing minikube using domain '%s' and vm-driver '%s'\n", o.Domain, o.VMDriver)
 	s.Successf("Requirements are fine")
-
-	fmt.Printf("Preparing minikube using domain '%s' and vm-driver '%s'\n", o.Domain, o.VMDriver)
-	fmt.Println()
 
 	s = o.NewStep("Check minikube status")
 	err = checkIfMinikubeIsInitialized(o, s)
@@ -149,14 +147,14 @@ func (o *MinikubeOptions) Run() error {
 	}
 	s.Successf("Minukube up and running")
 
-	fmt.Println("Adding hostnames, please enter your password if requested")
+	s = o.NewStep(fmt.Sprintf("Adjusting minikube cluster"))
+	s.LogInfo("Adding hostnames, please enter your password if requested")
 	err = addDevDomainsToEtcHosts(o)
 	if err != nil {
 		return err
 	}
-	fmt.Println("Hostnames added to " + HostsFile)
+	s.LogInfof("Hostnames added to %s", HostsFile)
 
-	s = o.NewStep(fmt.Sprintf("Adjusting minikube cluster"))
 	err = increaseFsInotifyMaxUserInstances(o)
 	if err != nil {
 		s.Failure()

--- a/pkg/kyma/cmd/provision/minikube/hosts_darwin.go
+++ b/pkg/kyma/cmd/provision/minikube/hosts_darwin.go
@@ -1,5 +1,4 @@
-// +build !windows
-// +build !darwin
+// +build darwin
 
 package minikube
 
@@ -10,7 +9,7 @@ import (
 
 const hostsFile = "/etc/hosts"
 
-const defaultVMDriver = vmDriverNone
+const defaultVMDriver = vmDriverHyperkit
 
 func addDevDomainsToEtcHostsOSSpecific(o *MinikubeOptions, s step.Step, hostAlias string) error {
 	s.LogInfo("Please enter your password if requested")

--- a/pkg/kyma/cmd/provision/minikube/hosts_others.go
+++ b/pkg/kyma/cmd/provision/minikube/hosts_others.go
@@ -6,13 +6,15 @@ import (
 	"github.com/kyma-incubator/kyma-cli/internal"
 )
 
+const HostsFile = "/etc/hosts"
+
 func addDevDomainsToEtcHostsOSSpecific(o *MinikubeOptions, hostAlias string) error {
-	_, err := internal.RunCmd("sudo", []string{"/bin/sh", "-c", "sed -i '' \"/" + o.Domain + "/d\" " + internal.HOSTS_FILE})
+	_, err := internal.RunCmd("sudo", []string{"/bin/sh", "-c", "sed -i '' \"/" + o.Domain + "/d\" " + HostsFile})
 	if err != nil {
 		return err
 	}
 
-	_, err = internal.RunCmd("sudo", []string{"/bin/sh", "-c", "echo '" + hostAlias + "' >> " + internal.HOSTS_FILE})
+	_, err = internal.RunCmd("sudo", []string{"/bin/sh", "-c", "echo '" + hostAlias + "' >> " + HostsFile})
 	if err != nil {
 		return err
 	}

--- a/pkg/kyma/cmd/provision/minikube/hosts_windows.go
+++ b/pkg/kyma/cmd/provision/minikube/hosts_windows.go
@@ -1,17 +1,21 @@
+// +build windows
+
 package minikube
 
 import (
 	"fmt"
+
+	"github.com/kyma-incubator/kyma-cli/internal/step"
 )
 
-const HostsFile = "C:\\Windows\\system32\\drivers\\etc\\hosts"
+const hostsFile = "C:\\Windows\\system32\\drivers\\etc\\hosts"
 
-func addDevDomainsToEtcHostsOSSpecific(o *MinikubeOptions, hostAlias string) error {
-	fmt.Println()
-	fmt.Println("=====")
-	fmt.Println("Please add these lines to your " + HostsFile + " file:")
+const defaultVMDriver = vmDriverVirtualBox
+
+func addDevDomainsToEtcHostsOSSpecific(o *MinikubeOptions, s step.Step, hostAlias string) error {
+
+	s.LogErrorf("Please add these lines to your " + hostsFile + " file:")
 	fmt.Println(hostAlias)
-	fmt.Println("=====")
 
 	return nil
 }

--- a/pkg/kyma/cmd/provision/minikube/hosts_windows.go
+++ b/pkg/kyma/cmd/provision/minikube/hosts_windows.go
@@ -2,13 +2,14 @@ package minikube
 
 import (
 	"fmt"
-	"github.com/kyma-incubator/kyma-cli/internal"
 )
+
+const HostsFile = "C:\\Windows\\system32\\drivers\\etc\\hosts"
 
 func addDevDomainsToEtcHostsOSSpecific(o *MinikubeOptions, hostAlias string) error {
 	fmt.Println()
 	fmt.Println("=====")
-	fmt.Println("Please add these lines to your " + internal.HOSTS_FILE + " file:")
+	fmt.Println("Please add these lines to your " + HostsFile + " file:")
 	fmt.Println(hostAlias)
 	fmt.Println("=====")
 

--- a/pkg/kyma/cmd/test.go
+++ b/pkg/kyma/cmd/test.go
@@ -45,9 +45,9 @@ func NewTestCmd(o *TestOptions) *cobra.Command {
 	return cmd
 }
 
-func (opts *TestOptions) Run() error {
+func (o *TestOptions) Run() error {
 	helmConfig := &environment.EnvSettings{TillerConnectionTimeout: 300}
-	kubeConfig, err := opts.GetKubeconfig()
+	kubeConfig, err := o.GetKubeconfig()
 	if err != nil {
 		return err
 	}
@@ -63,7 +63,7 @@ func (opts *TestOptions) Run() error {
 	}
 
 	for _, namespace := range namespacesToClean {
-		err := opts.cleanHelmTestPods(namespace)
+		err := o.cleanHelmTestPods(namespace)
 		if err != nil {
 			return err
 		}
@@ -71,19 +71,19 @@ func (opts *TestOptions) Run() error {
 
 	for _, component := range components {
 		release := component.Name
-		s := opts.NewStep(
+		s := o.NewStep(
 			fmt.Sprintf("Testing release %s", release),
 		)
 		s.Start()
 
-		if opts.skipRelease(helmClient, release) {
+		if o.skipRelease(helmClient, release) {
 			s.Successf("Skipping release %s", release)
 			continue
 		}
 
-		msg, success, err := opts.testRelease(helmClient, s, release)
+		msg, success, err := o.testRelease(helmClient, s, release)
 		s.Stop(success)
-		if msg != "" && (!success || opts.Verbose) {
+		if msg != "" && (!success || o.Verbose) {
 			fmt.Println("--- Log ---")
 			fmt.Print(msg)
 			fmt.Println("---")
@@ -96,8 +96,8 @@ func (opts *TestOptions) Run() error {
 	return nil
 }
 
-func (opts *TestOptions) skipRelease(client helm.Interface, release string) bool {
-	for _, skipped := range opts.skip {
+func (o *TestOptions) skipRelease(client helm.Interface, release string) bool {
+	for _, skipped := range o.skip {
 		if skipped == release {
 			return true
 		}
@@ -106,13 +106,13 @@ func (opts *TestOptions) skipRelease(client helm.Interface, release string) bool
 	return false
 }
 
-func (opts *TestOptions) cleanHelmTestPods(namespace string) error {
-	s := opts.NewStep(
+func (o *TestOptions) cleanHelmTestPods(namespace string) error {
+	s := o.NewStep(
 		fmt.Sprintf("Cleaning up helm test pods in namespace %s", namespace),
 	)
 	s.Start()
 
-	_, err := kubectl.RunCmd([]string{"delete", "pod", "-n", namespace, "-l", "helm-chart-test=true"})
+	_, err := kubectl.RunCmd(o.Verbose, "delete", "pod", "-n", namespace, "-l", "helm-chart-test=true")
 	if err != nil {
 		s.Failure()
 		return err
@@ -122,7 +122,7 @@ func (opts *TestOptions) cleanHelmTestPods(namespace string) error {
 	return nil
 }
 
-func (opts *TestOptions) testRelease(client helm.Interface, s step.Step, release string) (string, bool, error) {
+func (o *TestOptions) testRelease(client helm.Interface, s step.Step, release string) (string, bool, error) {
 	c, errc := client.RunReleaseTest(release, helm.ReleaseTestTimeout(600))
 	out := &bytes.Buffer{}
 	failed := 0

--- a/pkg/kyma/cmd/test.go
+++ b/pkg/kyma/cmd/test.go
@@ -71,9 +71,7 @@ func (o *TestOptions) Run() error {
 
 	for _, component := range components {
 		release := component.Name
-		s := o.NewStep(
-			fmt.Sprintf("Testing release %s", release),
-		)
+		s := o.NewStep(fmt.Sprintf("Testing release %s", release))
 		s.Start()
 
 		if o.skipRelease(helmClient, release) {

--- a/pkg/kyma/cmd/test.go
+++ b/pkg/kyma/cmd/test.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/kyma-incubator/kyma-cli/internal"
 	kyma_helm "github.com/kyma-incubator/kyma-cli/internal/helm"
 	"github.com/kyma-incubator/kyma-cli/internal/installer"
+	"github.com/kyma-incubator/kyma-cli/internal/kubectl"
 	"github.com/kyma-incubator/kyma-cli/internal/step"
 	"github.com/kyma-incubator/kyma-cli/pkg/kyma/core"
 	"github.com/spf13/cobra"
@@ -112,7 +112,7 @@ func (opts *TestOptions) cleanHelmTestPods(namespace string) error {
 	)
 	s.Start()
 
-	_, err := internal.RunKubectlCmd([]string{"delete", "pod", "-n", namespace, "-l", "helm-chart-test=true"})
+	_, err := kubectl.RunCmd([]string{"delete", "pod", "-n", namespace, "-l", "helm-chart-test=true"})
 	if err != nil {
 		s.Failure()
 		return err

--- a/pkg/kyma/cmd/uninstall.go
+++ b/pkg/kyma/cmd/uninstall.go
@@ -98,7 +98,7 @@ func (o *UninstallOptions) Run() error {
 	}
 	s.Successf("ClusterRoleBinding for admin deleted")
 
-	s = o.NewStep("Cleanup Namespaces")
+	s = o.NewStep("Deleting Namespaces")
 	// see https://github.com/kyma-project/kyma/issues/1826
 	err = deleteLeftoverResources(o, s, "namespace", namespacesToDelete)
 	if err != nil {
@@ -107,14 +107,14 @@ func (o *UninstallOptions) Run() error {
 	}
 	s.Successf("Namespaces deleted")
 
-	s = o.NewStep("Cleanup CRDs")
+	s = o.NewStep("Deleting CRDs")
 	// see https://github.com/kyma-project/kyma/issues/1826
 	err = deleteLeftoverResources(o, s, "crd", crdGroupsToDelete)
 	if err != nil {
 		s.Failure()
 		return err
 	}
-	s.Successf("CRDs cleaned")
+	s.Successf("CRDs deleted")
 
 	err = printUninstallSummary(o)
 	if err != nil {

--- a/pkg/kyma/cmd/uninstall.go
+++ b/pkg/kyma/cmd/uninstall.go
@@ -99,6 +99,7 @@ func (o *UninstallOptions) Run() error {
 	s.Successf("ClusterRoleBinding for admin deleted")
 
 	s = o.NewStep(fmt.Sprintf("Cleanup Namespaces"))
+	// see https://github.com/kyma-project/kyma/issues/1826
 	err = deleteLeftoverResources(o, "namespace", namespacesToDelete)
 	if err != nil {
 		s.Failure()
@@ -107,6 +108,7 @@ func (o *UninstallOptions) Run() error {
 	s.Successf("Namespaces deleted")
 
 	s = o.NewStep(fmt.Sprintf("Cleanup CRDs"))
+	// see https://github.com/kyma-project/kyma/issues/1826
 	err = deleteLeftoverResources(o, "crd", crdGroupsToDelete)
 	if err != nil {
 		s.Failure()

--- a/pkg/kyma/cmd/uninstall.go
+++ b/pkg/kyma/cmd/uninstall.go
@@ -51,7 +51,7 @@ The command will:
 
 //Run runs the command
 func (o *UninstallOptions) Run() error {
-	s := o.NewStep(fmt.Sprintf("Checking requirements"))
+	s := o.NewStep("Checking requirements")
 	err := checkUninstallRequirements(o, s)
 	if err != nil {
 		s.Failure()
@@ -59,9 +59,7 @@ func (o *UninstallOptions) Run() error {
 	}
 	s.Successf("Requirements are fine")
 
-	fmt.Printf("%s Uninstalling Kyma\n", step.InfoGliph)
-
-	s = o.NewStep(fmt.Sprintf("Activate kyma-installer to uninstall kyma"))
+	s = o.NewStep("Activate kyma-installer to uninstall kyma")
 	err = activateInstallerForUninstall(o)
 	if err != nil {
 		s.Failure()
@@ -69,12 +67,14 @@ func (o *UninstallOptions) Run() error {
 	}
 	s.Successf("kyma-installer activated to uninstall kyma")
 
+	s = o.NewStep("Uninstalling Kyma")
 	err = waitForInstallerToUninstall(o)
 	if err != nil {
 		return err
 	}
+	s.Successf("Kyma uninstalled successfully")
 
-	s = o.NewStep(fmt.Sprintf("Deleting kyma-installer"))
+	s = o.NewStep("Deleting kyma-installer")
 	err = deleteInstaller(o)
 	if err != nil {
 		s.Failure()
@@ -82,7 +82,7 @@ func (o *UninstallOptions) Run() error {
 	}
 	s.Successf("kyma-installer deleted")
 
-	s = o.NewStep(fmt.Sprintf("Deleting tiller"))
+	s = o.NewStep("Deleting tiller")
 	err = deleteTiller(o)
 	if err != nil {
 		s.Failure()
@@ -90,7 +90,7 @@ func (o *UninstallOptions) Run() error {
 	}
 	s.Successf("tiller deleted")
 
-	s = o.NewStep(fmt.Sprintf("Deleting ClusterRoleBinding for admin"))
+	s = o.NewStep("Deleting ClusterRoleBinding for admin")
 	err = deleteClusterRoleBinding(o)
 	if err != nil {
 		s.Failure()
@@ -98,7 +98,7 @@ func (o *UninstallOptions) Run() error {
 	}
 	s.Successf("ClusterRoleBinding for admin deleted")
 
-	s = o.NewStep(fmt.Sprintf("Cleanup Namespaces"))
+	s = o.NewStep("Cleanup Namespaces")
 	// see https://github.com/kyma-project/kyma/issues/1826
 	err = deleteLeftoverResources(o, "namespace", namespacesToDelete)
 	if err != nil {
@@ -107,7 +107,7 @@ func (o *UninstallOptions) Run() error {
 	}
 	s.Successf("Namespaces deleted")
 
-	s = o.NewStep(fmt.Sprintf("Cleanup CRDs"))
+	s = o.NewStep("Cleanup CRDs")
 	// see https://github.com/kyma-project/kyma/issues/1826
 	err = deleteLeftoverResources(o, "crd", crdGroupsToDelete)
 	if err != nil {

--- a/pkg/kyma/cmd/uninstall.go
+++ b/pkg/kyma/cmd/uninstall.go
@@ -52,8 +52,9 @@ func (o *UninstallOptions) Run() error {
 		s.Failure()
 		return err
 	}
-	s.LogInfo("Uninstalling Kyma\n")
 	s.Successf("Requirements are fine")
+
+	fmt.Printf("%s Uninstalling Kyma\n", step.InfoGliph)
 
 	s = o.NewStep(fmt.Sprintf("Activate kyma-installer to uninstall kyma"))
 	err = activateInstallerForUninstall(o)

--- a/pkg/kyma/cmd/uninstall.go
+++ b/pkg/kyma/cmd/uninstall.go
@@ -52,10 +52,8 @@ func (o *UninstallOptions) Run() error {
 		s.Failure()
 		return err
 	}
+	s.LogInfo("Uninstalling Kyma\n")
 	s.Successf("Requirements are fine")
-
-	fmt.Printf("Uninstalling Kyma\n")
-	fmt.Println()
 
 	s = o.NewStep(fmt.Sprintf("Activate kyma-installer to uninstall kyma"))
 	err = activateInstallerForUninstall(o)

--- a/pkg/kyma/cmd/version.go
+++ b/pkg/kyma/cmd/version.go
@@ -39,7 +39,6 @@ func NewVersionCmd(o *VersionOptions) *cobra.Command {
 
 //Run runs the command
 func (o *VersionOptions) Run() error {
-
 	version := Version
 	if version == "" {
 		version = "N/A"
@@ -47,7 +46,7 @@ func (o *VersionOptions) Run() error {
 	fmt.Printf("Kyma CLI version: %s\n", version)
 
 	if !o.Client {
-		version, err := internal.GetKymaVersion()
+		version, err := internal.GetKymaVersion(o.Verbose)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
- Adjusted requirement checks to use spinner logs for warnings
- Adjusted minikube version warning to include the version numbers as it was hard to guess which version es recommended
- Moved kubectl helper file into dedicated package
- Used verbose flag for kubectl and minikube commands
- Moved gliph in spinner message to start of line
- introduced new gliphs for spinner
- Have a better vmdriver default for windows
- Using simple spinner only for windows