### PR TITLE
1.0.0 prep work

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -60,12 +60,12 @@
   revision = "9c37978a95bd5c709a15883b6242714ea6709e64"
 
 [[projects]]
-  digest = "1:2fd83c8c2b1ff53fd7c4376a63c3a2f31e002e9296df9d7f150b07da524de88d"
+  digest = "1:5b290e0afae8906d379aa7fe01ce2007930636bdb80a96e148346131dd433cb8"
   name = "github.com/briandowns/spinner"
   packages = ["."]
   pruneopts = "UT"
-  revision = "dd69c579ff204842e8962816987f838e2c2c18d8"
-  version = "1.4"
+  revision = "ac46072a5a9105597c1fd63f9e246477b116772e"
+  version = "1.6"
 
 [[projects]]
   branch = "master"
@@ -320,7 +320,7 @@
   version = "1.1.4"
 
 [[projects]]
-  digest = "1:f430bbd1fcc1590e2720c1be647150535a5cba42d3bb11254903c0c6a10ffb7a"
+  digest = "1:27657d18e0425800d65e62baa043a023263ca5e345098f56c0e59589b652b320"
   name = "github.com/kyma-project/kyma"
   packages = [
     "components/installer/pkg/apis/installer/v1alpha1",
@@ -329,8 +329,8 @@
     "components/installer/pkg/client/clientset/versioned/typed/installer/v1alpha1",
   ]
   pruneopts = "UT"
-  revision = "1620e7c79788996e0abbdf8d4243273d64db591d"
-  version = "0.8.2"
+  revision = "ecbd761ec6c8fa4ff000d093dd3f0435cf6a931a"
+  version = "0.9.1"
 
 [[projects]]
   digest = "1:c658e84ad3916da105a761660dcaeb01e63416c8ec7bc62256a9b411a05fcd67"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -13,7 +13,7 @@ required = [
 
 [[constraint]]
   name = "github.com/kyma-project/kyma"
-  version = "0.9.1"
+  version = "1.0.0-rc2"
 
 [[constraint]]
   name = "github.com/pkg/errors"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -13,7 +13,7 @@ required = [
 
 [[constraint]]
   name = "github.com/kyma-project/kyma"
-  version = "1.0.0-rc2"
+  version = "1.0.0"
 
 [[constraint]]
   name = "github.com/pkg/errors"

--- a/pkg/kyma/cmd/install/cmd.go
+++ b/pkg/kyma/cmd/install/cmd.go
@@ -713,6 +713,7 @@ func (cmd *command) patchMinikubeIP() error {
 
 	patchMap := map[string][]string{
 		"configmap/application-connector-overrides": []string{"application-registry.minikubeIP"},
+		"configmap/core-overrides":                  []string{"test.acceptance.ui.minikubeIP", "apiserver-proxy.minikubeIP", "configurations-generator.minikubeIP"},
 		"configmap/assetstore-overrides":            []string{"asset-store-controller-manager.minikubeIP", "test.integration.minikubeIP"},
 	}
 	for k, v := range patchMap {

--- a/pkg/kyma/cmd/install/cmd.go
+++ b/pkg/kyma/cmd/install/cmd.go
@@ -58,7 +58,7 @@ The command will:
 		Aliases: []string{"i"},
 	}
 
-	cobraCmd.Flags().StringVarP(&o.ReleaseVersion, "release", "r", "1.0.0-rc2", "kyma release to use")
+	cobraCmd.Flags().StringVarP(&o.ReleaseVersion, "release", "r", "1.0.0", "kyma release to use")
 	cobraCmd.Flags().StringVarP(&o.ReleaseConfig, "config", "c", "", "URL or path to the installer configuration yaml")
 	cobraCmd.Flags().BoolVarP(&o.NoWait, "noWait", "n", false, "Do not wait for completion of kyma-installer")
 	cobraCmd.Flags().StringVarP(&o.Domain, "domain", "d", "kyma.local", "domain to use for installation")

--- a/pkg/kyma/cmd/install/cmd.go
+++ b/pkg/kyma/cmd/install/cmd.go
@@ -58,7 +58,7 @@ The command will:
 		Aliases: []string{"i"},
 	}
 
-	cobraCmd.Flags().StringVarP(&o.ReleaseVersion, "release", "r", "0.9.1", "kyma release to use")
+	cobraCmd.Flags().StringVarP(&o.ReleaseVersion, "release", "r", "1.0.0-rc2", "kyma release to use")
 	cobraCmd.Flags().StringVarP(&o.ReleaseConfig, "config", "c", "", "URL or path to the installer configuration yaml")
 	cobraCmd.Flags().BoolVarP(&o.NoWait, "noWait", "n", false, "Do not wait for completion of kyma-installer")
 	cobraCmd.Flags().StringVarP(&o.Domain, "domain", "d", "kyma.local", "domain to use for installation")
@@ -712,9 +712,8 @@ func (cmd *command) patchMinikubeIP() error {
 	minikubeIP = strings.TrimSpace(minikubeIP)
 
 	patchMap := map[string][]string{
-		"configmap/application-connector-overrides":   []string{"application-registry.minikubeIP"},
-		"configmap/assetstore-overrides":              []string{"asset-store-controller-manager.minikubeIP", "test.integration.minikubeIP"},
-		"configmap/core-test-ui-acceptance-overrides": []string{"test.acceptance.ui.minikubeIP"},
+		"configmap/application-connector-overrides": []string{"application-registry.minikubeIP"},
+		"configmap/assetstore-overrides":            []string{"asset-store-controller-manager.minikubeIP", "test.integration.minikubeIP"},
 	}
 	for k, v := range patchMap {
 		for _, pData := range v {


### PR DESCRIPTION
Currently only using 1.0.0-rc2

Installer seems stuck in a loop, checking for core component. Have not investigated further so far.
```bash
! You are using an unsupported kubectl version '1.14.0'. This may not work. It is recommended to use kubectl version '1.12.0'
✓ Requirements are fine
  Installing Kyma in version '1.0.0-rc2'
✓ Tiller installed
✓ kyma-installer installed
✓ Helm configured
✓ kyma-installer is installing kyma
✓ Waiting for installation to start
✕ Error installing Kyma: Processing component istio
  To fetch the logs from the installer execute: 'kubectl logs -n kyma-installer -l name=kyma-installer'
✓ Processing component istio
✓ Processing component xip-patch
✓ Processing component knative-serving
✓ Processing component knative-eventing
✓ Processing component istio-kyma-patch
✓ Processing component service-catalog
✓ Processing component helm-broker
✓ Processing component nats-streaming
✓ Processing component assetstore
✓ Processing component cms
✕ Error installing Kyma: Processing component core
  To fetch the logs from the installer execute: 'kubectl logs -n kyma-installer -l name=kyma-installer'
✓ Processing component istio
✓ Processing component knative-eventing
✓ Processing component istio-kyma-patch
✓ Processing component service-catalog
✓ Processing component helm-broker
✕ Error installing Kyma: Processing component core
  To fetch the logs from the installer execute: 'kubectl logs -n kyma-installer -l name=kyma-installer'
✓ Processing component cluster-essentials
✓ Processing component istio
✓ Processing component xip-patch
✓ Processing component istio-kyma-patch
✓ Processing component dex
✓ Processing component service-catalog
✓ Processing component service-catalog-addons
✕ Error installing Kyma: Processing component core
  To fetch the logs from the installer execute: 'kubectl logs -n kyma-installer -l name=kyma-installer'
✓ Processing component cluster-essentials
✓ Processing component istio
✓ Processing component xip-patch
✓ Processing component istio-kyma-patch
✓ Processing component dex
✓ Processing component service-catalog
✓ Processing component service-catalog-addons
✓ Processing component nats-streaming
✕ Error installing Kyma: Processing component core
  To fetch the logs from the installer execute: 'kubectl logs -n kyma-installer -l name=kyma-installer'
✓ Processing component cluster-essentials
✓ Processing component istio
✓ Processing component xip-patch
✓ Processing component istio-kyma-patch
✓ Processing component dex
✓ Processing component service-catalog
✓ Processing component service-catalog-addons
✓ Processing component nats-streaming
✕ Error installing Kyma: Processing component core
  To fetch the logs from the installer execute: 'kubectl logs -n kyma-installer -l name=kyma-installer'
✓ Processing component istio-init
✓ Processing component istio
✓ Processing component knative-serving
✓ Processing component istio-kyma-patch
✓ Processing component service-catalog
✓ Processing component helm-broker
✓ Processing component nats-streaming
✕ Error installing Kyma: Processing component core
  To fetch the logs from the installer execute: 'kubectl logs -n kyma-installer -l name=kyma-installer'
✓ Processing component istio-init
✓ Processing component istio
✓ Processing component knative-serving
✓ Processing component istio-kyma-patch
✓ Processing component service-catalog
✓ Processing component helm-broker
✕ Error installing Kyma: Processing component core
  To fetch the logs from the installer execute: 'kubectl logs -n kyma-installer -l name=kyma-installer'
✓ Processing component istio
✓ Processing component knative-serving
✓ Processing component istio-kyma-patch
/ Processing component service-catalog 
```